### PR TITLE
Add collection model and expose collection tracking fields

### DIFF
--- a/prisma/migrations/20250821195517_add_collection/migration.sql
+++ b/prisma/migrations/20250821195517_add_collection/migration.sql
@@ -1,0 +1,83 @@
+-- CreateEnum
+CREATE TYPE "MintStatus" AS ENUM ('PENDING', 'MINTING', 'MINTED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "ListingStatus" AS ENUM ('ACTIVE', 'SOLD', 'CANCELLED', 'EXPIRED');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mints" (
+    "id" TEXT NOT NULL,
+    "tokenId" TEXT NOT NULL,
+    "metadata" JSONB,
+    "txHash" TEXT,
+    "status" "MintStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "collectionId" TEXT,
+
+    CONSTRAINT "mints_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "listings" (
+    "id" TEXT NOT NULL,
+    "tokenId" TEXT NOT NULL,
+    "price" TEXT NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'ETH',
+    "status" "ListingStatus" NOT NULL DEFAULT 'ACTIVE',
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "collectionId" TEXT,
+
+    CONSTRAINT "listings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "collections" (
+    "id" TEXT NOT NULL,
+    "collectionMint" TEXT NOT NULL,
+    "authorityPubkey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "collections_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_username_key" ON "users"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mints_tokenId_key" ON "mints"("tokenId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "collections_collectionMint_key" ON "collections"("collectionMint");
+
+-- AddForeignKey
+ALTER TABLE "mints" ADD CONSTRAINT "mints_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mints" ADD CONSTRAINT "mints_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "collections"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "listings" ADD CONSTRAINT "listings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "listings" ADD CONSTRAINT "listings_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "collections"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,8 @@ model Mint {
   // Relations
   userId   String
   user     User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  collectionId String?
+  collection   Collection? @relation(fields: [collectionId], references: [id])
 
   @@map("mints")
 }
@@ -53,8 +55,24 @@ model Listing {
   // Relations
   userId      String
   user        User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  collectionId String?
+  collection   Collection? @relation(fields: [collectionId], references: [id])
 
   @@map("listings")
+}
+
+model Collection {
+  id              String   @id @default(cuid())
+  collectionMint  String   @unique
+  authorityPubkey String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  // Relations
+  mints    Mint[]
+  listings Listing[]
+
+  @@map("collections")
 }
 
 enum MintStatus {

--- a/src/modules/nft/routes.ts
+++ b/src/modules/nft/routes.ts
@@ -5,6 +5,9 @@ import { ApiResponse, MintRequest, ListingRequest } from '@/types/api';
 const mintSchema = z.object({
   tokenId: z.string().min(1),
   metadata: z.record(z.unknown()).optional(),
+  collectionId: z.string().min(1).optional(),
+  collectionMint: z.string().min(1).optional(),
+  authorityPubkey: z.string().min(1).optional(),
 });
 
 const listingSchema = z.object({
@@ -12,6 +15,7 @@ const listingSchema = z.object({
   price: z.string().min(1),
   currency: z.string().default('ETH'),
   expiresAt: z.string().datetime().optional(),
+  collectionId: z.string().min(1).optional(),
 });
 
 export default async function nftRoutes(
@@ -30,6 +34,9 @@ export default async function nftRoutes(
         properties: {
           tokenId: { type: 'string', minLength: 1 },
           metadata: { type: 'object' },
+          collectionId: { type: 'string' },
+          collectionMint: { type: 'string' },
+          authorityPubkey: { type: 'string' },
         },
       },
     },
@@ -77,6 +84,7 @@ export default async function nftRoutes(
           price: { type: 'string', minLength: 1 },
           currency: { type: 'string' },
           expiresAt: { type: 'string', format: 'date-time' },
+          collectionId: { type: 'string' },
         },
       },
     },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -8,6 +8,9 @@ export interface ApiResponse<T = unknown> {
 export interface MintRequest {
   tokenId: string;
   metadata?: Record<string, unknown>;
+  collectionId?: string;
+  collectionMint?: string;
+  authorityPubkey?: string;
 }
 
 export interface ListingRequest {
@@ -15,4 +18,5 @@ export interface ListingRequest {
   price: string;
   currency?: string;
   expiresAt?: string;
+  collectionId?: string;
 }


### PR DESCRIPTION
## Summary
- add `Collection` model with mint and authority tracking
- link `Mint` and `Listing` to `Collection`
- accept collection fields in NFT API routes and types

## Testing
- `npm test`
- `npm run lint`
- `npm run db:generate`
- `npx prisma migrate dev --name add-collection --create-only` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7793471048320b1b3aca43e023e1f