### PR TITLE
feat: add collections module with stats

### DIFF
--- a/src/__tests__/collections.test.ts
+++ b/src/__tests__/collections.test.ts
@@ -1,0 +1,71 @@
+import { buildApp } from '../app';
+import { FastifyInstance } from 'fastify';
+
+describe('Collections Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should create and retrieve a collection', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/collections',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Test Collection' }),
+    });
+
+    expect(createRes.statusCode).toBe(200);
+    const createBody = JSON.parse(createRes.body);
+    const collectionId = createBody.data.collectionId;
+    expect(collectionId).toBeDefined();
+
+    const listRes = await app.inject({ method: 'GET', url: '/collections' });
+    expect(listRes.statusCode).toBe(200);
+    const listBody = JSON.parse(listRes.body);
+    expect(Array.isArray(listBody.data)).toBe(true);
+    expect(listBody.data.length).toBeGreaterThan(0);
+
+    const getRes = await app.inject({ method: 'GET', url: `/collections/${collectionId}` });
+    expect(getRes.statusCode).toBe(200);
+    const getBody = JSON.parse(getRes.body);
+    expect(getBody.data.id).toBe(collectionId);
+  });
+
+  it('should add item and return correct stats', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/collections',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Stats Collection' }),
+    });
+    const collectionId = JSON.parse(createRes.body).data.collectionId;
+
+    const price = '1000000000000000000';
+    const addRes = await app.inject({
+      method: 'POST',
+      url: `/collections/${collectionId}/items`,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tokenId: 'token1', price }),
+    });
+    expect(addRes.statusCode).toBe(200);
+
+    const statsRes = await app.inject({
+      method: 'GET',
+      url: `/collections/${collectionId}/stats`,
+    });
+    expect(statsRes.statusCode).toBe(200);
+    const statsBody = JSON.parse(statsRes.body);
+    expect(statsBody.data.total).toBe(1);
+    expect(statsBody.data.listed).toBe(1);
+    expect(statsBody.data.floorPrice).toBe(price);
+    expect(statsBody.data.volume).toBe(price);
+    expect(typeof statsBody.data.floorPrice).toBe('string');
+  });
+});
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { config } from './config/env';
 // Import route modules
 import healthRoutes from './modules/health/routes';
 import nftRoutes from './modules/nft/routes';
+import collectionsRoutes from './modules/collections/routes';
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -28,6 +29,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   // Register routes
   await app.register(healthRoutes);
   await app.register(nftRoutes);
+  await app.register(collectionsRoutes);
 
   // Global error handler
   app.setErrorHandler((error, request, reply) => {

--- a/src/modules/collections/routes.ts
+++ b/src/modules/collections/routes.ts
@@ -1,0 +1,214 @@
+import { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import { z } from 'zod';
+
+import {
+  ApiResponse,
+  CreateCollectionRequest,
+  AddItemRequest,
+  Collection,
+  CollectionStats,
+} from '@/types/api';
+
+interface InternalCollectionItem {
+  tokenId: string;
+  price: bigint; // stored as BigInt internally
+}
+
+interface InternalCollection {
+  id: string;
+  name: string;
+  description?: string;
+  items: InternalCollectionItem[];
+}
+
+const collections: Record<string, InternalCollection> = {};
+
+const createCollectionSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
+const addItemSchema = z.object({
+  tokenId: z.string().min(1),
+  price: z.string().optional(),
+});
+
+export default async function collectionsRoutes(
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions
+) {
+  // Create collection
+  fastify.post<{
+    Body: CreateCollectionRequest;
+    Reply: ApiResponse<{ collectionId: string }>;
+  }>('/collections', async (request, reply) => {
+    try {
+      const body = createCollectionSchema.parse(request.body);
+
+      const id = `col_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      collections[id] = {
+        id,
+        name: body.name,
+        description: body.description,
+        items: [],
+      };
+
+      return {
+        success: true,
+        data: { collectionId: id },
+        message: 'Collection created successfully',
+      };
+    } catch (error) {
+      fastify.log.error(error);
+      return reply.code(400).send({
+        success: false,
+        error: error instanceof Error ? error.message : 'Invalid request data',
+      });
+    }
+  });
+
+  // List collections
+  fastify.get<{ Reply: ApiResponse<Collection[]> }>(
+    '/collections',
+    async () => {
+      const data: Collection[] = Object.values(collections).map((col) => ({
+        id: col.id,
+        name: col.name,
+        description: col.description,
+        items: col.items.map((item) => ({
+          tokenId: item.tokenId,
+          price: item.price.toString(),
+        })),
+      }));
+      return { success: true, data };
+    }
+  );
+
+  // Get collection by id
+  fastify.get<{
+    Params: { id: string };
+    Reply: ApiResponse<Collection | null>;
+  }>('/collections/:id', async (request, reply) => {
+    const { id } = request.params;
+    const col = collections[id];
+    if (!col) {
+      return reply.code(404).send({
+        success: false,
+        error: 'Collection not found',
+      });
+    }
+
+    const data: Collection = {
+      id: col.id,
+      name: col.name,
+      description: col.description,
+      items: col.items.map((item) => ({
+        tokenId: item.tokenId,
+        price: item.price.toString(),
+      })),
+    };
+
+    return { success: true, data };
+  });
+
+  // Add item to collection
+  fastify.post<{
+    Params: { id: string };
+    Body: AddItemRequest;
+    Reply: ApiResponse<{ tokenId: string }>;
+  }>('/collections/:id/items', async (request, reply) => {
+    try {
+      const { id } = request.params;
+      const col = collections[id];
+      if (!col) {
+        return reply.code(404).send({
+          success: false,
+          error: 'Collection not found',
+        });
+      }
+
+      const body = addItemSchema.parse(request.body);
+      const price = body.price ? BigInt(body.price) : BigInt(0);
+
+      col.items.push({ tokenId: body.tokenId, price });
+
+      return {
+        success: true,
+        data: { tokenId: body.tokenId },
+        message: 'Item added to collection',
+      };
+    } catch (error) {
+      fastify.log.error(error);
+      return reply.code(400).send({
+        success: false,
+        error: error instanceof Error ? error.message : 'Invalid request data',
+      });
+    }
+  });
+
+  // Remove item from collection
+  fastify.delete<{
+    Params: { id: string; tokenId: string };
+    Reply: ApiResponse<{ tokenId: string }>;
+  }>('/collections/:id/items/:tokenId', async (request, reply) => {
+    const { id, tokenId } = request.params;
+    const col = collections[id];
+    if (!col) {
+      return reply.code(404).send({
+        success: false,
+        error: 'Collection not found',
+      });
+    }
+
+    const index = col.items.findIndex((i) => i.tokenId === tokenId);
+    if (index === -1) {
+      return reply.code(404).send({
+        success: false,
+        error: 'Item not found in collection',
+      });
+    }
+
+    col.items.splice(index, 1);
+
+    return {
+      success: true,
+      data: { tokenId },
+      message: 'Item removed from collection',
+    };
+  });
+
+  // Collection stats
+  fastify.get<{
+    Params: { id: string };
+    Reply: ApiResponse<CollectionStats>;
+  }>('/collections/:id/stats', async (request, reply) => {
+    const { id } = request.params;
+    const col = collections[id];
+    if (!col) {
+      return reply.code(404).send({
+        success: false,
+        error: 'Collection not found',
+      });
+    }
+
+    const total = col.items.length;
+    const listedItems = col.items.filter((item) => item.price > 0n);
+    const listed = listedItems.length;
+
+    const floorPrice = listedItems.length
+      ? listedItems.reduce((min, item) => (item.price < min ? item.price : min), listedItems[0].price)
+      : BigInt(0);
+
+    const volume = col.items.reduce((sum, item) => sum + item.price, BigInt(0));
+
+    const data: CollectionStats = {
+      total,
+      listed,
+      floorPrice: floorPrice.toString(),
+      volume: volume.toString(),
+    };
+
+    return { success: true, data };
+  });
+}
+

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -16,3 +16,33 @@ export interface ListingRequest {
   currency?: string;
   expiresAt?: string;
 }
+
+// Collection related types
+export interface CreateCollectionRequest {
+  name: string;
+  description?: string;
+}
+
+export interface CollectionItem {
+  tokenId: string;
+  price?: string; // serialized BigInt
+}
+
+export interface Collection {
+  id: string;
+  name: string;
+  description?: string;
+  items: CollectionItem[];
+}
+
+export interface AddItemRequest {
+  tokenId: string;
+  price?: string;
+}
+
+export interface CollectionStats {
+  total: number;
+  listed: number;
+  floorPrice: string;
+  volume: string;
+}


### PR DESCRIPTION
## Summary
- add collection module with create/list/get routes
- support adding/removing NFT items
- expose stats endpoint with bigint values serialized to strings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7793426388320ab5e746ded6423e7