### PR TITLE
feat: add offline collection workflow tests

### DIFF
--- a/src/__tests__/collections.test.ts
+++ b/src/__tests__/collections.test.ts
@@ -1,0 +1,66 @@
+import { buildApp } from '../app';
+import { FastifyInstance } from 'fastify';
+
+// Mock RPC module to keep tests offline
+jest.mock('../modules/collections/rpc', () => ({
+  mintCollection: jest.fn().mockResolvedValue({ collectionId: 'mock-collection' }),
+  addItem: jest.fn().mockResolvedValue({ itemId: 'mock-item' }),
+  getStats: jest.fn().mockResolvedValue({ itemCount: 42 }),
+}));
+
+import * as rpc from '../modules/collections/rpc';
+
+describe('Collection Routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('mints a collection', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/collections/mint',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Test Collection' }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(true);
+    expect(body.data.collectionId).toBe('mock-collection');
+    expect(rpc.mintCollection).toHaveBeenCalledWith({ name: 'Test Collection' });
+  });
+
+  it('adds an item to a collection', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/collections/mock-collection/items',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ item: { name: 'Item 1' } }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(true);
+    expect(body.data.itemId).toBe('mock-item');
+    expect(rpc.addItem).toHaveBeenCalledWith({ collectionId: 'mock-collection', item: { name: 'Item 1' } });
+  });
+
+  it('retrieves collection stats', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/collections/mock-collection/stats',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(true);
+    expect(body.data.itemCount).toBe(42);
+    expect(rpc.getStats).toHaveBeenCalledWith({ collectionId: 'mock-collection' });
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { config } from './config/env';
 // Import route modules
 import healthRoutes from './modules/health/routes';
 import nftRoutes from './modules/nft/routes';
+import collectionRoutes from './modules/collections/routes';
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -28,6 +29,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   // Register routes
   await app.register(healthRoutes);
   await app.register(nftRoutes);
+  await app.register(collectionRoutes);
 
   // Global error handler
   app.setErrorHandler((error, request, reply) => {

--- a/src/modules/collections/routes.ts
+++ b/src/modules/collections/routes.ts
@@ -1,0 +1,89 @@
+import { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import { z } from 'zod';
+import { ApiResponse } from '@/types/api';
+import { mintCollection, addItem, getStats } from './service';
+
+const mintSchema = z.object({
+  name: z.string().min(1),
+});
+
+const addItemSchema = z.object({
+  item: z.record(z.unknown()),
+});
+
+export default async function collectionRoutes(
+  fastify: FastifyInstance,
+  options: FastifyPluginOptions
+) {
+  // POST /collections/mint
+  fastify.post<{
+    Body: { name: string };
+    Reply: ApiResponse<{ collectionId: string }>;
+  }>(
+    '/collections/mint',
+    async (request, reply) => {
+      try {
+        const body = mintSchema.parse(request.body);
+        const data = await mintCollection(body.name);
+        return {
+          success: true,
+          data,
+          message: 'Collection minted successfully',
+        };
+      } catch (error) {
+        return reply.code(400).send({
+          success: false,
+          error: error instanceof Error ? error.message : 'Invalid request data',
+        });
+      }
+    }
+  );
+
+  // POST /collections/:id/items
+  fastify.post<{
+    Params: { id: string };
+    Body: { item: Record<string, unknown> };
+    Reply: ApiResponse<{ itemId: string }>;
+  }>(
+    '/collections/:id/items',
+    async (request, reply) => {
+      try {
+        const params = request.params;
+        const body = addItemSchema.parse(request.body);
+        const data = await addItem(params.id, body.item);
+        return {
+          success: true,
+          data,
+          message: 'Item added successfully',
+        };
+      } catch (error) {
+        return reply.code(400).send({
+          success: false,
+          error: error instanceof Error ? error.message : 'Invalid request data',
+        });
+      }
+    }
+  );
+
+  // GET /collections/:id/stats
+  fastify.get<{
+    Params: { id: string };
+    Reply: ApiResponse<{ itemCount: number }>;
+  }>(
+    '/collections/:id/stats',
+    async (request, reply) => {
+      try {
+        const data = await getStats(request.params.id);
+        return {
+          success: true,
+          data,
+        };
+      } catch (error) {
+        return reply.code(400).send({
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get stats',
+        });
+      }
+    }
+  );
+}

--- a/src/modules/collections/rpc.ts
+++ b/src/modules/collections/rpc.ts
@@ -1,0 +1,15 @@
+export async function mintCollection(params: { name: string }): Promise<{ collectionId: string }> {
+  // In a real implementation, this would make an external RPC call to mint a collection
+  // Here we return a placeholder response. Tests will mock this function to avoid network access.
+  return { collectionId: `collection_${Date.now()}` };
+}
+
+export async function addItem(params: { collectionId: string; item: Record<string, unknown> }): Promise<{ itemId: string }> {
+  // Placeholder for external RPC call to add an item to a collection
+  return { itemId: `item_${Date.now()}` };
+}
+
+export async function getStats(params: { collectionId: string }): Promise<{ itemCount: number }> {
+  // Placeholder for external RPC call to fetch collection statistics
+  return { itemCount: 0 };
+}

--- a/src/modules/collections/service.ts
+++ b/src/modules/collections/service.ts
@@ -1,0 +1,13 @@
+import * as rpc from './rpc';
+
+export async function mintCollection(name: string) {
+  return rpc.mintCollection({ name });
+}
+
+export async function addItem(collectionId: string, item: Record<string, unknown>) {
+  return rpc.addItem({ collectionId, item });
+}
+
+export async function getStats(collectionId: string) {
+  return rpc.getStats({ collectionId });
+}


### PR DESCRIPTION
## Summary
- add collection module for minting, adding items, and retrieving stats
- cover collection workflow with Jest tests and RPC mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77bfd61048320b0eb92bdf5ec4564